### PR TITLE
Remove binary after zipping it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build: build/$(RELEASE)
 build/$(RELEASE): $(SRC)
 	@echo "== Build =="
 	CGO_ENABLED=0 GOOS=$(TARGET) GOARCH=$(ARCH) go build -o build/$(BINARY) -v cmd/main.go
-	zip build/$(RELEASE) build/$(BINARY)
+	zip -m build/$(RELEASE) build/$(BINARY)
 	
 	# Create a copy of the zip with a static filename for uploading to github releases
 	cp build/$(RELEASE) build/concourse-sts-lambda.zip


### PR DESCRIPTION
The S3 folder will include the binary if it is part of the `build` folder. Removing the binary after zipping it seems fair to do anyway, and fixes it 👍 